### PR TITLE
feature/moving-main-ingredient

### DIFF
--- a/src/components/Dish.tsx
+++ b/src/components/Dish.tsx
@@ -17,9 +17,9 @@ export default function Dish({ dish, dishIngredient, onMouseEnter, handleDeleteD
     >
       <Image
         objectFit="cover"
-        maxW={['100%', '180px']}
+        w={['100%', '180px']}
         src={dish?.image ? dish?.image : placeholderImage}
-        maxH={['140px', '100%', '100%']}
+        maxH={['140px', '140px', '140px']}
         alt="dish"
         borderRadius={5}
       />
@@ -33,9 +33,19 @@ export default function Dish({ dish, dishIngredient, onMouseEnter, handleDeleteD
             <Text fontSize={['15', '18']} fontWeight="600">
               Ingredienser:
             </Text>
-            <Text fontSize={['14', '16']} py={['4px', '4px', '1.5']}>
-              {dishIngredient}
-            </Text>
+            <Flex flexFlow={'wrap'} mb="4px">
+              {dishIngredient.map((ingredient, i, { length }) => (
+                <Text
+                  as="span"
+                  key={Math.random()}
+                  _first={{ fontWeight: '600' }}
+                  fontSize={['14', '16']}
+                  py={['2px', '2px', '2px']}
+                >
+                  {length - 1 === i ? ingredient : `${ingredient},\u00A0`}
+                </Text>
+              ))}
+            </Flex>
           </Flex>
         </Box>
 

--- a/src/pages/dishes/index.tsx
+++ b/src/pages/dishes/index.tsx
@@ -70,10 +70,10 @@ export default function DishList() {
       .catch(() => alert.error('Borttagning misslyckad'))
   }
 
-  function getDishIngredients(dish: Dish): string {
+  function getDishIngredients(dish: Dish) {
     return !!dish.ingredients && dish.ingredients.length > 0
-      ? dish.ingredients.map((i) => i.grocery.name).join(', ')
-      : ''
+      ? dish.ingredients.reverse().map((i) => i.grocery.name)
+      : []
   }
 
   return (

--- a/src/pages/dishes/view/[dish].tsx
+++ b/src/pages/dishes/view/[dish].tsx
@@ -114,9 +114,8 @@ export default function ViewDishPage() {
           Ingredients
         </Heading>
         <UnorderedList>
-          {/* <ListItem>{data?.dish?.mainIngredient.name}</ListItem> */}
-          {data?.dish?.ingredients.map((ingredient) => (
-            <ListItem key={ingredient.grocery.id}>
+          {data?.dish?.ingredients.reverse().map((ingredient) => (
+            <ListItem _first={{ fontWeight: '700' }} key={ingredient.grocery.id}>
               <span>{ingredient.quantity} </span>
               {ingredient.grocery.name}
             </ListItem>
@@ -179,7 +178,6 @@ export default function ViewDishPage() {
           src={data?.dish?.image ? data?.dish?.image : placeholderImage}
           alt="Dish Image"
           borderRadius={8}
-          mb={6}
         />
       </Flex>
       <Flex bgColor="white" borderRadius={8} padding={4} mb={8} flexDirection="column">
@@ -196,9 +194,8 @@ export default function ViewDishPage() {
             Ingredients
           </Heading>
           <UnorderedList>
-            {/* <ListItem>{data?.mainIngredient.name}</ListItem> */}
             {data?.dish?.ingredients.map((ingredient) => (
-              <ListItem key={ingredient.grocery.id}>
+              <ListItem _first={{ fontWeight: '700' }} key={ingredient.grocery.id}>
                 <span>{ingredient.quantity} </span>
                 {ingredient.grocery.name}
               </ListItem>

--- a/src/services/hooks/useDishes.ts
+++ b/src/services/hooks/useDishes.ts
@@ -37,7 +37,7 @@ export async function getDishes(page: number, pageLimit = {}): Promise<GetDishes
       ingredients: dish.ingredients,
       image: dish.image,
       recipe: dish.recipe,
-      mainIngredint: dish.mainIngredient,
+      mainIngredient: dish.mainIngredient,
       temperature: dish.temperature,
       rate: dish.rate,
       portions: dish.portions,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moved the main ingredient to be the first ingredient in the list and render in bold weight.

## Motivation and Context
We think the main ingredient is the more relevant ingredient in a dish and deserve to be highlighted somehow.

## Trello task associated
[<!-- If there's a Trello task associated to this PR, please share it here-->](https://trello.com/c/klzjkkZv/75-set-main-ingredient-bold-and-put-it-first-when-import-from-file)

## Screenshots
![image](https://user-images.githubusercontent.com/9136002/213393859-ba8f6e45-fdb2-45ed-8d7b-ae7de3545b77.png)
![image](https://user-images.githubusercontent.com/9136002/213393924-d55a6cb6-81d2-423b-9fc8-7be8f2650c20.png)

## Can this PR be merged now?
<!-- Choose the one that matches the status of this PR-->
 - [x] Yes, the task is completed and it is working as expected
 - [ ] No, this PR is a WIP and **MUST NOT BE MERGED YET** :)

## Any additional notes?
 <!-- if there is something you need to add that doesn't fit in any of the previous sections, add it here -->
