### PR TITLE
Add options on mobile [Categories and groceries]

### DIFF
--- a/src/pages/categories/index.tsx
+++ b/src/pages/categories/index.tsx
@@ -14,7 +14,9 @@ import {
   Tbody,
   Td,
   useBreakpointValue,
-  Spinner
+  Spinner,
+  MenuItem,
+  Show
 } from '@chakra-ui/react'
 import { RiEditLine, RiDeleteBinLine } from 'react-icons/ri'
 import Link from 'next/link'
@@ -26,6 +28,7 @@ import TooltipButton from '../../components/TooltipButton'
 import { useAlert } from 'react-alert'
 import { useCategories } from '../../services/hooks/useCategories'
 import PageWrapper from '../page-wrapper'
+import { MenuDishOptions } from '../../components/Options'
 
 type Category = {
   id: string
@@ -107,35 +110,53 @@ export default function CategoryList() {
                   <Tr key={category.id}>
                     <Td>
                       <Box>
-                        <Text fontSize={[14, 16, 20]} fontWeight="bold" textTransform="capitalize">
+                        <Text fontSize={[16, 16, 20]} fontWeight="bold" textTransform="capitalize">
                           {category.name}
                         </Text>
                       </Box>
                     </Td>
                     <Td>
-                      <HStack>
-                        <Tooltip label="Remove" bg="red.100" color="white" placement="top-start">
-                          <Button
-                            size={['xs', 'sm']}
-                            bg="red.100"
-                            color="white"
-                            justifyContent="center"
-                            leftIcon={<Icon as={RiDeleteBinLine} fontSize="16" />}
-                            iconSpacing="0"
-                            _hover={{ bg: 'red.200' }}
-                            onClick={() => handleDelete(category.id)}
-                          />
-                        </Tooltip>
-                        <Link href={`/categories/edit/${category.id}`} passHref>
-                          <TooltipButton
-                            tooltipLabel="Redigera"
-                            size={['xs', 'sm']}
-                            bg="gray.200"
-                            leftIcon={<Icon as={RiEditLine} fontSize="16" />}
-                            iconSpacing="0"
-                          />
-                        </Link>
-                      </HStack>
+                      <Show breakpoint="(max-width: 400px)">
+                        <MenuDishOptions
+                          replace={
+                            <Link href={`/categories/edit/${category.id}`} passHref>
+                              <MenuItem
+                                fontSize="16"
+                                color="gray.700"
+                                icon={<RiEditLine size={16} />}
+                              >
+                                Redigera
+                              </MenuItem>
+                            </Link>
+                          }
+                          deleteDish={() => handleDelete(category.id)}
+                        />
+                      </Show>
+                      <Show breakpoint="(min-width: 400px)">
+                        <HStack>
+                          <Tooltip label="Remove" bg="red.100" color="white" placement="top-start">
+                            <Button
+                              size={['xs', 'sm']}
+                              bg="red.100"
+                              color="white"
+                              justifyContent="center"
+                              leftIcon={<Icon as={RiDeleteBinLine} fontSize="16" />}
+                              iconSpacing="0"
+                              _hover={{ bg: 'red.200' }}
+                              onClick={() => handleDelete(category.id)}
+                            />
+                          </Tooltip>
+                          <Link href={`/categories/edit/${category.id}`} passHref>
+                            <TooltipButton
+                              tooltipLabel="Redigera"
+                              size={['xs', 'sm']}
+                              bg="gray.200"
+                              leftIcon={<Icon as={RiEditLine} fontSize="16" />}
+                              iconSpacing="0"
+                            />
+                          </Link>
+                        </HStack>
+                      </Show>
                     </Td>
                   </Tr>
                 ))}

--- a/src/pages/groceries/index.tsx
+++ b/src/pages/groceries/index.tsx
@@ -14,7 +14,9 @@ import {
   Tbody,
   Td,
   useBreakpointValue,
-  Spinner
+  Spinner,
+  MenuItem,
+  Show
 } from '@chakra-ui/react'
 import { RiEditLine, RiDeleteBinLine } from 'react-icons/ri'
 import Link from 'next/link'
@@ -26,6 +28,7 @@ import { HTTPHandler } from '../../services/api'
 import TooltipButton from '../../components/TooltipButton'
 import { useAlert } from 'react-alert'
 import PageWrapper from '../page-wrapper'
+import { MenuDishOptions } from '../../components/Options'
 
 type UseGroceryData = {
   items: Grocery[]
@@ -91,12 +94,12 @@ export default function GroceryList() {
               <Thead bg="gray.200" color="black">
                 <Tr>
                   <Th fontSize={[14, 15, 18]}>ingrediens</Th>
-                  <Th fontSize={[14, 15, 18]}>kategori</Th>
-                  {isWideVersion && (
-                    <Th fontSize={[14, 16, 18]} width="8">
-                      händelser
-                    </Th>
-                  )}
+                  <Show breakpoint="(min-width: 400px)">
+                    <Th fontSize={[14, 15, 18]}>kategori</Th>
+                  </Show>
+                  <Th fontSize={[14, 16, 18]} width="8">
+                    händelser
+                  </Th>
                 </Tr>
               </Thead>
               <Tbody>
@@ -109,15 +112,33 @@ export default function GroceryList() {
                         </Text>
                       </Box>
                     </Td>
-                    <Td>
-                      {grocery.category && (
-                        <Text fontSize={[14, 16, 18]} textTransform="capitalize">
-                          {grocery.category.name}
-                        </Text>
-                      )}
-                    </Td>
-                    {isWideVersion && (
+                    <Show breakpoint="(min-width: 400px)">
                       <Td>
+                        {grocery.category && (
+                          <Text fontSize={[14, 16, 18]} textTransform="capitalize">
+                            {grocery.category.name}
+                          </Text>
+                        )}
+                      </Td>
+                    </Show>
+                    <Td>
+                      <Show breakpoint="(max-width: 400px)">
+                        <MenuDishOptions
+                          replace={
+                            <Link href={`/groceries/edit/${grocery.id}`} passHref>
+                              <MenuItem
+                                fontSize="16"
+                                color="gray.700"
+                                icon={<RiEditLine size={16} />}
+                              >
+                                Redigera
+                              </MenuItem>
+                            </Link>
+                          }
+                          deleteDish={() => handleDelete(grocery.id)}
+                        />
+                      </Show>
+                      <Show breakpoint="(min-width: 400px)">
                         <HStack>
                           <Tooltip label="Remove" bg="red.200" color="white" placement="top-start">
                             <Button
@@ -141,8 +162,8 @@ export default function GroceryList() {
                             />
                           </Link>
                         </HStack>
-                      </Td>
-                    )}
+                      </Show>
+                    </Td>
                   </Tr>
                 ))}
               </Tbody>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the Options menu with edit and delete actions when the page is mobile.

## Motivation and Context
The user must be able to execute this actions no matter the device she/he is using.

## Trello task associated
[<!-- If there's a Trello task associated to this PR, please share it here-->](https://trello.com/b/ExIesDSA/food-and-shoping-assistant)

## Screenshots
![image](https://user-images.githubusercontent.com/9136002/214243047-bfe65bb7-bbb4-4c4d-b582-be7a793fbcce.png)
![image](https://user-images.githubusercontent.com/9136002/214243142-e764aa41-f961-4bde-8c1e-354df06028b1.png)
![image](https://user-images.githubusercontent.com/9136002/214243235-7dd48277-e608-41e4-8fa4-6059cfd969eb.png)


## Can this PR be merged now?
<!-- Choose the one that matches the status of this PR-->
 - [x] Yes, the task is completed and it is working as expected
 - [ ] No, this PR is a WIP and **MUST NOT BE MERGED YET** :)

## Any additional notes?
 <!-- if there is something you need to add that doesn't fit in any of the previous sections, add it here -->
