### PR TITLE
Bug/avoid duplicated ingredients on dish

### DIFF
--- a/src/components/Form/DishForm.tsx
+++ b/src/components/Form/DishForm.tsx
@@ -89,6 +89,7 @@ export default function DishForm(props: DishFormParams) {
 
   const [addIngredient, setAddIngredient] = useState<boolean>()
   const [showEditIngredient, setShowEditIngredient] = useState<boolean>()
+  const [ingredientExists, setIngredientExists] = useState<boolean>()
 
   const defaultValues = {
     ...props.initialData,
@@ -128,7 +129,6 @@ export default function DishForm(props: DishFormParams) {
 
     setValue('ingredientName', ingredient.name)
     setValue('ingredientQuantity', ingredient.quantity)
-
     setIndexIngredient(index)
   }
 
@@ -138,6 +138,7 @@ export default function DishForm(props: DishFormParams) {
     setIngredientId(el.id)
     setAddIngredient(true)
     setShowEditIngredient(true)
+    setIndexIngredient(null)
   }
 
   const addNewIngredient = () => {
@@ -167,6 +168,14 @@ export default function DishForm(props: DishFormParams) {
     }
 
     setShowEditIngredient(false)
+  }
+
+  const handleAddorUpdate = (el) => {
+    const nameExists = fields.map((item) => item?.name).includes(el.name)
+
+    const index = fields.map((item) => item?.name).indexOf(el.name)
+    setIngredientExists(nameExists)
+    nameExists ? openIngredientTag(fields[index], index) : addIngredientName(el)
   }
 
   const isWideVersion = useBreakpointValue(
@@ -266,10 +275,11 @@ export default function DishForm(props: DishFormParams) {
             <SearchIngredient
               name="Sök ingrediens"
               label="Sök Ingrediens"
-              onAddIngredient={addIngredientName}
+              onAddIngredient={handleAddorUpdate}
             ></SearchIngredient>
             {showEditIngredient && (
               <EditIngredient
+                isAdded={ingredientExists}
                 handleDeleteDish={() => {
                   remove(indexIngredient)
                   setShowEditIngredient(false)
@@ -285,7 +295,7 @@ export default function DishForm(props: DishFormParams) {
                 (ingredient: { id: string; name: string; quantity: string }, index: number) => (
                   <Tag
                     p="0.4em"
-                    onClick={() => openIngredientTag(ingredient, index)}
+                    onClick={() => handleAddorUpdate(ingredient)}
                     cursor="pointer"
                     fontSize={['14px', '18px']}
                     key={ingredient.id}

--- a/src/components/Form/EditIngredient.tsx
+++ b/src/components/Form/EditIngredient.tsx
@@ -7,7 +7,8 @@ const EditIngredient = ({
   setShowEditIngredient,
   errors,
   addIngredient,
-  handleDeleteDish
+  handleDeleteDish,
+  isAdded
 }) => {
   return (
     <Box
@@ -39,15 +40,19 @@ const EditIngredient = ({
           />
         </Flex>
         <Flex justifyContent="space-between" w="100%">
-          <Button
-            size={['sm', 'md']}
-            bg="red.100"
-            color="white"
-            leftIcon={<Icon as={RiDeleteBinLine} fontSize="16" />}
-            iconSpacing="0"
-            _hover={{ bg: 'red.200' }}
-            onClick={() => handleDeleteDish()}
-          ></Button>
+          {isAdded ? (
+            <Button
+              size={['sm', 'md']}
+              bg="red.100"
+              color="white"
+              leftIcon={<Icon as={RiDeleteBinLine} fontSize="16" />}
+              iconSpacing="0"
+              _hover={{ bg: 'red.200' }}
+              onClick={() => handleDeleteDish()}
+            ></Button>
+          ) : (
+            <Box />
+          )}
           <Box>
             <Button
               _hover={{ bg: 'white' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a validation to avoid adding the same ingredient multiple times to the dish. Instead, if you try to add an ingredient that's already in the ingedients list, it will open the "Edit dish" component.

## Motivation and Context
The user were able to add the same ingredient multiple times.

## Trello task associated
https://trello.com/c/BPKkVsUf/80-dont-allow-duplicates-when-choosing-an-ingredient

## Can this PR be merged now?
<!-- Choose the one that matches the status of this PR-->
 - [x] Yes, the task is completed and it is working as expected
 - [ ] No, this PR is a WIP and **MUST NOT BE MERGED YET** :)
