### PR TITLE
Removing extra data picker on menu view

### DIFF
--- a/src/components/Form/DatePicker/WeekPicker.tsx
+++ b/src/components/Form/DatePicker/WeekPicker.tsx
@@ -1,15 +1,24 @@
-import { useEffect, useState } from 'react'
-import DatePicker from 'react-datepicker'
+import { Input } from '@chakra-ui/react'
+import { Dispatch, useEffect, useState } from 'react'
+import ReactDatePicker from 'react-datepicker'
 
-export const WeekPicker = ({ setWeek }) => {
+export const WeekPicker = ({
+  setWeek,
+  definedWeek
+}: {
+  setWeek: Dispatch<object>
+  definedWeek?: object
+}) => {
   const [startDate, setStartDate] = useState(null)
   const [endDate, setEndDate] = useState(null)
+
   const onChange = (date) => {
     const week = getWeekRange(date)
 
     const [startDay, endDay] = week
 
     setWeek([startDay, endDay])
+
     setStartDate(startDay)
     setEndDate(endDay)
   }
@@ -39,18 +48,24 @@ export const WeekPicker = ({ setWeek }) => {
   }
 
   useEffect(() => {
-    onChange(new Date())
+    const selectedWeek = definedWeek ? new Date(definedWeek[0]) : new Date()
+    onChange(selectedWeek)
   }, [])
 
   return (
-    <DatePicker
+    <Input
+      as={ReactDatePicker}
       id="weekly-date-picker"
       selected={startDate}
       onChange={onChange}
       startDate={startDate}
-      endDate={endDate}
+      endDate={definedWeek ? definedWeek[1] : endDate}
       minDate={new Date()}
       calendarStartDay={1}
+      fontSize={['sm', 'md']}
+      size={['sm', 'md']}
+      backgroundColor="white"
+      w={['95%']}
       onKeyDown={(e) => {
         e.preventDefault()
       }}

--- a/src/pages/menu/index.tsx
+++ b/src/pages/menu/index.tsx
@@ -197,13 +197,15 @@ export default function Menu() {
             Veckomeny
           </Heading>
         </Flex>
-        <WeekPicker setWeek={setWeek} />
         {!menuForChoosenWeekExists ? (
-          <Flex>
-            <Button mt="20px" onClick={() => generateMenu()}>
-              Generera Veckomeny
-            </Button>
-          </Flex>
+          <>
+            <WeekPicker definedWeek={week} setWeek={setWeek} />
+            <Flex>
+              <Button mt="20px" onClick={() => generateMenu()}>
+                Generera Veckomeny
+              </Button>
+            </Flex>
+          </>
         ) : isLoading || isFetching || !localData ? (
           <Box w="100%" m="auto">
             <Spinner size="lg" color="gray.500" ml="4" />
@@ -219,13 +221,11 @@ export default function Menu() {
                   <Controller
                     name="startDate"
                     control={control}
-                    render={({ field: { onChange, value } }) => (
-                      <DatePicker isDisabled selected={value} onChange={(date) => onChange(date)} />
-                    )}
+                    render={() => <WeekPicker definedWeek={week} setWeek={setWeek} />}
                   />
                 </Box>
 
-                <Box>
+                <Box ml="10px">
                   <Text mb="5px" fontSize={['sm', 'md']}>
                     Till
                   </Text>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I changed and modified the data picker from the menu view

## Motivation and Context
there were two data picker components and it was not necessary

## Trello task associated
https://trello.com/c/UTaaGJLx/64-menu-view-fixes

## Screenshots
![image](https://user-images.githubusercontent.com/9136002/215795423-4419666c-13bf-4d53-b93b-77202c893c1d.png)
![image](https://user-images.githubusercontent.com/9136002/215795565-28a7e420-d93e-4d59-8556-b4b837442926.png)

## Can this PR be merged now?
<!-- Choose the one that matches the status of this PR-->
 - [x] Yes, the task is completed and it is working as expected
 - [ ] No, this PR is a WIP and **MUST NOT BE MERGED YET** :)
