### PR TITLE
Fix pagination on ingredient page

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,4 +1,5 @@
 import { Stack, Box, Text } from '@chakra-ui/react'
+import { loadDefaultErrorComponents } from 'next/dist/server/load-components'
 import { PaginationItem } from './PaginationItem'
 
 interface PaginationProps {
@@ -30,6 +31,7 @@ export function Pagination({
 
   const previousPages =
     currentPage > 1 ? generatePagesArray(currentPage - 1 - siblingsCount, currentPage - 1) : []
+  console.log(previousPages)
   const nextPages =
     currentPage < lastPage
       ? generatePagesArray(currentPage, Math.min(currentPage + siblingsCount, lastPage))
@@ -45,7 +47,7 @@ export function Pagination({
     if (action === 'firstPage') {
       setOffset(0)
     }
-    if (action === 'nextPage') {
+    if (action === 'nextPage' && previousPages === null) {
       setOffset((prev: number) => prev + registersPerPage)
     }
     if (action === 'previousPage') {

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,5 +1,4 @@
 import { Stack, Box, Text } from '@chakra-ui/react'
-import { loadDefaultErrorComponents } from 'next/dist/server/load-components'
 import { PaginationItem } from './PaginationItem'
 
 interface PaginationProps {
@@ -31,7 +30,6 @@ export function Pagination({
 
   const previousPages =
     currentPage > 1 ? generatePagesArray(currentPage - 1 - siblingsCount, currentPage - 1) : []
-  console.log(previousPages)
   const nextPages =
     currentPage < lastPage
       ? generatePagesArray(currentPage, Math.min(currentPage + siblingsCount, lastPage))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The pagination works again 

## Motivation and Context
The page numbers got broken when the page offset when out of bounce

## Trello task associated
https://trello.com/c/b2FP8VaJ/91-fix-pagination-on-ingredient-page

## Screenshots
<!-- If your work add visual changes, please add some screenshots of the changes -->

## Can this PR be merged now?
<!-- Choose the one that matches the status of this PR-->
 - [x ] Yes, the task is completed and it is working as expected
 - [ ] No, this PR is a WIP and **MUST NOT BE MERGED YET** :)

## Any additional notes?
 <!-- if there is something you need to add that doesn't fit in any of the previous sections, add it here -->
